### PR TITLE
Updated transfer file

### DIFF
--- a/serTransfer.c
+++ b/serTransfer.c
@@ -28,7 +28,7 @@ task main()
 	//send dummy data
 	char buf[9];
 	buf[0] = 't';
-	bnsSerialSend(UART1, buf, 9);
+	bnsSerialSend(UART1, buf);
 	writeDebugStream("Sent dummy data\n");
 
 	


### PR DESCRIPTION
No need to specify number of bytes read, it is already done automatically. removed parameter from bnsSerialSend.